### PR TITLE
Deploy Previews

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,46 @@ jobs:
           bucket: mozilla-desktop-funnel-prototype
           source: /tmp/workspace/public
           options: -r
+  deploy-preview:
+    docker:
+      - image: google/cloud-sdk
+    working_directory: /tmp
+    steps:
+      - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+          at: /tmp/workspace
+      # shamelessly cribbed from https://circleci.com/developer/orbs/orb/samsalisbury/github-status
+      - run: |
+          set -euo pipefail
+          CONTEXT="circleci/$CIRCLE_JOB"
+          # Compose our URL and auth pieces
+          API=https://api.github.com
+          USER=$CIRCLE_PROJECT_USERNAME
+          REPO=$CIRCLE_PROJECT_REPONAME
+          SHA=$CIRCLE_SHA1
+          AUTH=$GITHUB_STATUS_USER:$GITHUB_STATUS_TOKEN
+          URL=$API/repos/$USER/$REPO/statuses/$SHA
+          # Compose the body.
+          BODY='
+            {
+              "state": "success",
+              "target_url": "https://protosaur.dev/numbers-that-matter/previews/'$CIRCLE_BRANCH'",
+              "description": "Deploy Preview",
+              "context": "'$CONTEXT'"
+            }
+          '
+          # Post the status (use echo-pipe not \<<< for greater shell compat).
+          echo $BODY | curl -u $AUTH -XPOST -d@- $URL
 workflows:
   build-and-test:
     jobs:
       - build-and-test
+      - deploy-preview:
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              ignore: main
       - upload:
           requires:
             - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,11 @@ jobs:
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
           at: /tmp/workspace
+      - gcs/gcs-rsync:
+          bucket: mozilla-desktop-funnel-prototype
+          source: /tmp/workspace/public
+          destination: "preview/$CIRCLE_BRANCH"
+          options: -r
       # shamelessly cribbed from https://circleci.com/developer/orbs/orb/samsalisbury/github-status
       - run: |
           set -euo pipefail
@@ -56,7 +61,7 @@ jobs:
           BODY='
             {
               "state": "success",
-              "target_url": "https://protosaur.dev/numbers-that-matter/previews/'$CIRCLE_BRANCH'",
+              "target_url": "https://protosaur.dev/numbers-that-matter/preview/'$CIRCLE_BRANCH'/",
               "description": "Deploy Preview",
               "context": "'$CONTEXT'"
             }


### PR DESCRIPTION
Similar to netlify deploy previews, this lets us get a bit of feedback on a proposed change without landing. PRs will get a "preview URL" under the main protosaur site which is posted in the github status e.g. https://protosaur.dev/numbers-that-matter/preview/deploy-previews/